### PR TITLE
Make DoAfterFramesTask a little more reliable

### DIFF
--- a/Assets/STasks/Scripts/Task Variants/DoAfterFramesTask.cs
+++ b/Assets/STasks/Scripts/Task Variants/DoAfterFramesTask.cs
@@ -2,10 +2,10 @@
 {
     public class DoAfterFramesTask : STask
     {
-        public int ElapsedFrames => _elapedFrames;
+        public int ElapsedFrames => _elapsedFrames;
 
         private int _targetFrames;
-        private int _elapedFrames;
+        private int _elapsedFrames;
 
         public DoAfterFramesTask(STaskSettings settings) : base(settings)
         {
@@ -14,14 +14,14 @@
 
         protected override float GetProgress()
         {
-            return (float)_elapedFrames / _targetFrames;
+            return (float)_elapsedFrames / _targetFrames;
         }
 
         protected override void OnUpdate(float deltaTime)
         {
-            _elapedFrames++;
+            _elapsedFrames++;
 
-            if (_elapedFrames == _targetFrames)
+            if (_elapsedFrames >= _targetFrames)
             {
                 Complete();
             }


### PR DESCRIPTION
It shouldn't happen, but in case we somehow miss an OnUpdate call on DoAfterFramesTask, >= should be more reliable of a comparison than ==.

Also, there was a typo in the name of the _elapsedFrames variable.