### PR TITLE
Make DoUntil live up to its name

### DIFF
--- a/Assets/STasks/Scripts/Task Variants/DoUntilTask.cs
+++ b/Assets/STasks/Scripts/Task Variants/DoUntilTask.cs
@@ -19,11 +19,7 @@
         {
             base.OnUpdate(deltaTime);
 
-            if (condition()) {
-              action.Invoke();
-            }
-            else
-            {
+            if (!condition()) {
                 Kill();
             }
         }

--- a/Assets/STasks/Scripts/Task Variants/DoUntilTask.cs
+++ b/Assets/STasks/Scripts/Task Variants/DoUntilTask.cs
@@ -8,14 +8,23 @@
         {
             condition = settings.condition;
         }
+        
+        protected override float GetProgress()
+        {
+            Debug.LogWarning($"{nameof(DoUntilTask)} can't keep track of the progress, you'll need to write your own implementation for this. Returning -1.");
+            return -1;
+        }
 
         protected override void OnUpdate(float deltaTime)
         {
             base.OnUpdate(deltaTime);
 
-            if (condition())
+            if (condition()) {
+              action.Invoke();
+            }
+            else
             {
-                Complete();
+                Kill();
             }
         }
     }


### PR DESCRIPTION
My understanding of DoUntil is that it should keep doing the action every frame UNTIL some condition is true. This change makes DoUntil behave that way. Currently it seems to be a clone of DoWhenTask.